### PR TITLE
fix: Command to Highlight Phrase Changed.

### DIFF
--- a/src/lib/ansiCodes.h
+++ b/src/lib/ansiCodes.h
@@ -1,25 +1,24 @@
 #ifndef ANSI_CODES_H
 #define ANSI_CODES_H
 
-// 'x1b' is called ESC at the ASCII table, to customize the text color, we always start with a ESC
+// --- ANSI Escape Codes
+
+// - 'x1b' is called ESC at the ASCII table, to customize the text color, we always start with a ESC
 #define ANSI_START "\x1b"
-// Control Sequence Introducer (CSI)
+// - Control Sequence Introducer (CSI)
 #define CSI "\x1b["
-// Clear Terminal
+// - Clear Terminal
 #define ANSI_CLEAR "\033c"
 
-/*
-Select Graphic Rendition Control Sequences
-*/
+// -- Select Graphic Rendition Control Sequences
 
-// ANSI Code to reset the Text Format
+// - Reset the Text Format
 #define ANSI_RESET "\x1b[0m"
-// ANSI Code to set the text Bold
+// - Set the text Bold
 #define ANSI_BOLD "\x1b[1m"
-// ANSI Code to Set a Slow Blink to the Text
+// - Set a Slow Blink to the Text
 #define ANSI_SLOW_BLINK "\x1b[5m"
-
-// The Command Prefix of the RGB Code
+// - The Command Prefix of the RGB Code
 #define ANSI_RGB_BG_COLOR "48;2"
 #define ANSI_RGB_FG_COLOR "38;2"
 

--- a/src/lib/filesOp.cpp
+++ b/src/lib/filesOp.cpp
@@ -56,7 +56,7 @@ void writeDefaultColor(char *filename, string fileContent)
   fstream writeFile(filename, fstream::out | fstream::binary);
   if (!writeFile.is_open() || (removeResult != 0 && removeResult != 1))
   {
-    cout << "\nError: Cannot Write to " << filename;
+    cout << "\nError: Cannot Write to " << filename; // Cannot write to file
   }
   else
   {
@@ -92,7 +92,7 @@ string readDefaultColor(bool readBgColor)
       colorFormatFile >> c;
       if (colorFormatFile.good())
       {
-        sgrCommand += c;
+        sgrCommand += c; // Read Command Stored on the file
       }
       else
       {
@@ -118,4 +118,11 @@ string readDefaultColor(bool readBgColor)
   colorFormatFile.close();
 
   return sgrCommand;
+}
+
+// Read both Background and Foreground Default Text Color Format
+string readCompleteDefaultColor()
+{
+  string sgrCommand = readDefaultColor(true);        // SGR Command of the Default Background Color
+  return sgrCommand.append(readDefaultColor(false)); // SGR Command of the Default Foreground Color
 }

--- a/src/lib/filesOp.h
+++ b/src/lib/filesOp.h
@@ -5,7 +5,7 @@ using std::string;
 
 namespace fs = std::filesystem;
 
-// GLobal Variables for the Filename of the Default Background and Foreground Color
+// Global Variables for the Filename of the Default Background and Foreground Color
 extern char bgColorFilename[], fgColorFilename[];
 
 #ifndef FILES_OP_H
@@ -14,5 +14,6 @@ extern char bgColorFilename[], fgColorFilename[];
 fs::path changeCwdToBin(string invokeCommand);
 void writeDefaultColor(char *filename, string fileContent);
 string readDefaultColor(bool readBgColor);
+string readCompleteDefaultColor();
 
 #endif

--- a/src/lib/input.cpp
+++ b/src/lib/input.cpp
@@ -1,24 +1,47 @@
 #include <iostream>
+#include <iomanip>
+#include <filesystem>
+#include "filesOp.h"
+#include "ansiCodes.h"
 
 using std::cin;
 using std::cout;
 using std::getline;
+using std::left;
+using std::setfill;
+using std::setw;
 using std::string;
+
+namespace fs = std::filesystem;
+
+// Print Section Title
+void printTitle(string sgrCommand, string message)
+{
+  int nTitle = 50; // Output String Size of the Section Titles
+
+  cout << CSI << sgrCommand << setw(nTitle) << setfill(' ') << left << message << ANSI_RESET << '\n';
+}
 
 // Help Message
 void helpMessage()
 {
+  string sgrCommand = readCompleteDefaultColor();
   string colorCommands[3] = {
-      "Background and Foreground [-c]", "Background [-b]", "Foreground [-f]"};
+      "[-c] Change Background and Foreground Color", "[-b] Change Background Color", "[-f] Change Foreground Color"};
 
-  cout << "Avalaible Commands:";
-  cout << "\n\n*** Help [-h]";
-  cout << "\n\n*** Change Default Text Color";
+  printTitle(sgrCommand, "MINIGREP");
+  cout << "Run:\n"
+       << "-- [phraseToHighlight... filePath...] To Highlight the Phrase"
+       << "\nCommands:\n"
+       << "-- [-h] Help\n";
+
   for (int i = 0; i < size(colorCommands); i++)
   {
-    cout << "\n--- " << colorCommands[i];
+    cout << "-- " << colorCommands[i] << '\n';
   }
-  cout << "\n\n*** Run\n--- To Find the Phrase : [filePath... phrase...]";
+
+  printTitle(sgrCommand, "CURRENT PATH");
+  cout << fs::current_path() << '\n';
 }
 
 // Boolean Question

--- a/src/lib/input.h
+++ b/src/lib/input.h
@@ -5,7 +5,8 @@ using std::string;
 #ifndef INPUT_H
 #define INPUT_H
 
-bool booleanQuestion(string message);
+void printTitle(string sgrCommand, string message);
 void helpMessage();
+bool booleanQuestion(string message);
 
 #endif

--- a/src/lib/rgbColor.cpp
+++ b/src/lib/rgbColor.cpp
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <iomanip>
 #include <string>
+#include "input.h"
 
 using std::cin;
 using std::cout;
@@ -19,6 +20,7 @@ void printColorSuggestions()
   const int charSizeColor = 4; // The Number of Whitespace Used on the Message with the Color as the Background
   int n, i, j, k;              // Counters
   string rgbColor;
+  string sgrCommand = readCompleteDefaultColor();
 
   int colorSuggestions[6][3][3] = {
       {{32, 32, 32},     // Dark Gray
@@ -47,17 +49,22 @@ void printColorSuggestions()
   int tintsPerColor = sizeof(colorSuggestions[0]) / numberRGB; // Tints Variations per Color of the Same Type
   int typesColor = numberColors / tintsPerColor;               // Number of Color Types
 
-  cout << "\t**** Some Color Suggestions ***\n";
+  cout << ANSI_CLEAR; // Clear terminal
+  printTitle(sgrCommand, "Some Color Suggestions");
   j = -1;
   for (n = 0; n < numberColors; n++)
   {
-    string sgrCommand = CSI; // WARNING: Its Content is being erase by Re-declaring in each Iteration
+    sgrCommand = CSI;
 
     if (n % typesColor == 0 || n == 0)
     {
       cout << "\n";
       i = 0;
       j++;
+    }
+    else
+    {
+      cout << string(2, ' '); // Whitespace Separation between Colors
     }
 
     // Print a Color with its Code Next to it
@@ -72,8 +79,8 @@ void printColorSuggestions()
     sgrCommand.append("m");
 
     // Cell with Color
-    cout << "\t" << sgrCommand << string(charSizeColor, ' ') << ANSI_RESET;
-    // RGB Number
+    cout << sgrCommand << string(charSizeColor, ' ') << ANSI_RESET;
+    // RGB Color Number
     for (k = 0; k < 3; k++)
     {
       cout << ' ' << setfill(' ') << setw(3) << colorSuggestions[i][j][k];
@@ -95,11 +102,12 @@ void saveRGB(string message, string csiPrefix, bool changeBgColor)
   {
     while (true)
     {
+      sgrCommand = readCompleteDefaultColor(); // SGR Command for the Title
+      cout << '\n';
+      printTitle(sgrCommand, message);
+
       sgrCommand = CSI;
-
       wrongValue = false;
-      cout << "\n\t" << message << ": ";
-
       for (int i = 0; i < 3; i++)
       {
         cin >> rgbString[i]; // 0: Red, 1: Green, 2: Blue
@@ -116,7 +124,7 @@ void saveRGB(string message, string csiPrefix, bool changeBgColor)
         try
         {
           n = stoi(rgbString[i]); // Converts the string to an int
-          if (n < 0 || n > 255)   // Checks if the Color is between 0 and 255
+          if (n < 0 || n > 255)   // Checks if the Color is not between 0 and 255
           {
             wrongValue = true;
           }
@@ -138,13 +146,11 @@ void saveRGB(string message, string csiPrefix, bool changeBgColor)
       }
 
       if (!wrongValue)
-      {
         break;
-      }
     }
 
     sgrCommand.append(csiPrefix);
-    // Loop to get the RGB part from a String Array for the Select Graphic Rendition (SGR)
+    // Loop to get the RGB Command for the Select Graphic Rendition (SGR)
     for (int i = 0; i < 3; i++)
     {
       sgrCommand.append(";");
@@ -154,9 +160,8 @@ void saveRGB(string message, string csiPrefix, bool changeBgColor)
 
     sgrAuxCommand = readDefaultColor(!changeBgColor); // Read the Other Default Text Color. If the User is Changing Background, this will Read the Default Foreground
 
-    cout
-        << "\n\t/// " << sgrCommand << sgrAuxCommand << " Example Text " << ANSI_RESET << " ///\n";
-    change = booleanQuestion("\n\t--- Do you want to save this Color as Default?");
+    cout << "\n-- " << sgrCommand << sgrAuxCommand << " Example Text " << ANSI_RESET << '\n';
+    change = booleanQuestion("-- Do you want to save this Color as Default?");
   } while (!change);
 
   // Save Color as the Default Configuration
@@ -177,10 +182,10 @@ void getRGBTextColor(bool changeBgColor)
 
   if (changeBgColor)
   {
-    saveRGB("*** Background Color", ANSI_RGB_BG_COLOR, changeBgColor);
+    saveRGB("Background Color", ANSI_RGB_BG_COLOR, changeBgColor);
   }
   else
   {
-    saveRGB("*** Foreground Color", ANSI_RGB_FG_COLOR, changeBgColor);
+    saveRGB("Foreground Color", ANSI_RGB_FG_COLOR, changeBgColor);
   }
 }

--- a/src/lib/rgbColor.h
+++ b/src/lib/rgbColor.h
@@ -7,9 +7,9 @@ using std::string;
 
 // Background and Foreground Colors in case of an error trying to Load the User's defined colors
 #define BG_RGB_ERROR ";32;32;32m"
-#define FG_RGB_ERROR ";0;255;128m"
+#define FG_RGB_ERROR ";153;204;255m"
 
-void printColorSuggestions();
+void printColorSuggestions(); // Example Colors
 void getRGBTextColor(bool changeBgColor);
 
 #endif


### PR DESCRIPTION
* Cleaned Code.
* Checked Code Comments.
* The Command Structure to Highlight the Phrase is the same when executed in the terminal or directly from the .exe.
* Added Colors to the Messages printed in the terminal, which are the same as the Default Text Color Configuration of the User.